### PR TITLE
correct formatting of twitter handle in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,7 @@ description: > # this means to ignore newlines until "baseurl:"
   (P2P) publishing platform and database all rolled into one.
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://aletheia-foundation.io" # the base hostname & protocol for your site, e.g. http://example.com
-twitter_username: @aletheia_f
+twitter_username: "@aletheia_f"
 github_username:  jekyll
 
 # Build settings


### PR DESCRIPTION
@KadeMorton Before we schedule time to chat more about Github pages and Jekyll, I took a look at your site and the build error. Turns out that Jekyll doesn't like having special characters at the beginning of yaml values, so this pull request will fix that. Let me know if you want to discuss and let's find a time to chat more. --Chris

This commit encapsulates the value for your twitter handle in quotes since jekyll doesn't like parsing special characters at the beginning of yaml values.

You can preview the built site with this change on my fork: https://critzo.github.io/aletheia-foundation.github.io/