### PR TITLE
Background scaling, header overflow fixed

### DIFF
--- a/_sass/common.sass
+++ b/_sass/common.sass
@@ -23,14 +23,14 @@ body
     height: 100vh
     /* https://pixabay.com/en/landscape-forest-trees-jungle-2584127/ */
     background-image: url("/images/bg_100pc.jpg")
-    background-size: 100% 100%
+    background-size: 100% auto
     background-attachment: fixed 
     margin: 0
     padding: 0
 
 @media screen and (max-width: $small_screen_max_width)
     body
-        background-size: auto 100%
+        background-size: 100% auto
 
 
 //@media screen and (max-resolution: $small_screen_dpi)

--- a/_sass/header.sass
+++ b/_sass/header.sass
@@ -4,7 +4,7 @@ header
     position: fixed
     top: 0
     left: 0
-    height: $header_height
+    /*height: $header_height*/
     line-height: $header_height
     background: black
     width: 100%


### PR DESCRIPTION
Background width fixed to 100% of body width, auto height to preserve original image proportions.
Header menu button overflow fixed (it was due to fixing header height to 34px, and menu button on small devices having 29px height + 8px padding.

## I confirm:

- [x] I've read the [contributing guidelines](https://github.com/aletheia-foundation/aletheia-admin/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/aletheia-foundation/aletheia-admin/blob/master/CODE-OF-CONDUCT.md)
- [x] I've checked that this issue applies to this repo
- [x] I've checked the existing issues, no one else has reported this
- [x] I've limited the subject line to 50 characters 
- [x] I've capitalised the subject line
- [x] I've not ended the subject line with a period
- [x] I've used the imperative mood in the subject line 

---------------------------

### Making an enhancement - ignore this if not making an enhancement

- [ ] I've **Checked** the [outstanding issues](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+user%3Aaletheia-foundation+). 
- [ ] I've **Read** the latest version of the [whitepaper](https://github.com/aletheia-foundation/whitepaper).
- [ ] I've **Emailed** contact@aletheia-foundation.io to discuss the enhancement. 
