### PR TITLE
Header overflow fixed

### DIFF
--- a/_sass/common.sass
+++ b/_sass/common.sass
@@ -3,8 +3,8 @@ $aletheia_grey: rgba(130,130,131,1)
 $aletheia_darkgreen: rgba(26,170,90,1)
 $aletheia_lightgreen: rgba(170,207,56,1)
 
-$small_screen_max_width: 740px
-$large_screen_min_width: 741px
+$small_screen_max_width: 770px
+$large_screen_min_width: 771px
 
 $small_screen_dpi: 100dpi
 $large_screen_dpi: 101dpi


### PR DESCRIPTION
On screens with width between 741px and 767px it is shown "full text header" over two lines. I changed small screen max-width to 770px.

## I confirm:

- [x] I've read the [contributing guidelines](https://github.com/aletheia-foundation/aletheia-admin/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/aletheia-foundation/aletheia-admin/blob/master/CODE-OF-CONDUCT.md)
- [x] I've checked that this issue applies to this repo
- [x] I've checked the existing issues, no one else has reported this
- [x] I've limited the subject line to 50 characters 
- [x] I've capitalised the subject line
- [x] I've not ended the subject line with a period
- [x] I've used the imperative mood in the subject line 

---------------------------

### Making an enhancement - ignore this if not making an enhancement

- [ ] I've **Checked** the [outstanding issues](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+user%3Aaletheia-foundation+). 
- [ ] I've **Read** the latest version of the [whitepaper](https://github.com/aletheia-foundation/whitepaper).
- [ ] I've **Emailed** contact@aletheia-foundation.io to discuss the enhancement. 
