### PR TITLE
Fix background image stretch

### DIFF
--- a/_sass/common.sass
+++ b/_sass/common.sass
@@ -14,7 +14,7 @@ body
     height: 100vh
     /* https://pixabay.com/en/landscape-forest-trees-jungle-2584127/ */
     background-image: url("/images/bg_100pc.jpg")
-    background-size: 100% 100%
+    background-size: cover
     background-attachment: fixed 
     margin: 0
     padding: 0
@@ -38,8 +38,6 @@ body
     min-height: 100%
 
 @media screen and (max-width: $small_screen_max_width)
-    body
-        background-size: auto 100%
     #post-container
         width: calc(100% - 40px)
 


### PR DESCRIPTION
The background image is stretching (distoring) on wide screens. I've made 2 changes to common.sass to fix this:

1. changing the body background-size to "cover"
2. removing the background-size rule in the media query for small screens, since it is no longer necessary

Related to issue #12 

## I confirm:

- [ ] I've read the [contributing guidelines](https://github.com/aletheia-foundation/aletheia-admin/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/aletheia-foundation/aletheia-admin/blob/master/CODE-OF-CONDUCT.md)
- [ ] I've checked that this issue applies to this repo
- [ ] I've checked the existing issues, no one else has reported this
- [ ] I've limited the subject line to 50 characters 
- [ ] I've capitalised the subject line
- [ ] I've not ended the subject line with a period
- [ ] I've used the imperative mood in the subject line 

---------------------------

### Making an enhancement - ignore this if not making an enhancement

- [ ] I've **Checked** the [outstanding issues](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+user%3Aaletheia-foundation+). 
- [ ] I've **Read** the latest version of the [whitepaper](https://github.com/aletheia-foundation/whitepaper).
- [ ] I've **Emailed** contact@aletheia-foundation.io to discuss the enhancement. 
